### PR TITLE
Add reconciliation tab and fiscal period management

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,10 +19,20 @@ let acctSheet="",acctCols={seg2:"",seg3:"",seg4:"",desc:"",active:""},acctMap=ne
 let actionsByKey={},items=[],reclassItems=[];
 let periodEnd="",fiscalYY="",actualMM="",seqStart="01",journalTitle="Standard Amortization Entry";
 let defaults={fyy:"",amm:"",amemo:"{{vendor}} {{invnum}} amortization ({{start}}–{{end}})",jnltitle:"Standard Amortization Entry"};
+let periods=[],closingPeriod="2025-10";
 let mode="amort";
 
-function save(){localStorage.setItem(STORAGE,JSON.stringify({profile,actionsByKey,items,reclassItems,periodEnd,fiscalYY,actualMM,seqStart,journalTitle,acctSheet,acctCols,defaults}))}
-function load(){try{const s=localStorage.getItem(STORAGE);if(s){const o=JSON.parse(s);profile=o.profile||profile;actionsByKey=o.actionsByKey||{};items=o.items||[];reclassItems=o.reclassItems||[];periodEnd=o.periodEnd||"";fiscalYY=o.fiscalYY||"";actualMM=o.actualMM||"";seqStart=o.seqStart||"01";journalTitle=o.journalTitle||journalTitle;acctSheet=o.acctSheet||"";acctCols=o.acctCols||acctCols;defaults=o.defaults||defaults}}catch{}}
+function save(){localStorage.setItem(STORAGE,JSON.stringify({profile,actionsByKey,items,reclassItems,periodEnd,fiscalYY,actualMM,seqStart,journalTitle,acctSheet,acctCols,defaults,periods,closingPeriod}))}
+function load(){try{const s=localStorage.getItem(STORAGE);if(s){const o=JSON.parse(s);profile=o.profile||profile;actionsByKey=o.actionsByKey||{};items=o.items||[];reclassItems=o.reclassItems||[];periodEnd=o.periodEnd||"";fiscalYY=o.fiscalYY||"";actualMM=o.actualMM||"";seqStart=o.seqStart||"01";journalTitle=o.journalTitle||journalTitle;acctSheet=o.acctSheet||"";acctCols=o.acctCols||acctCols;defaults=o.defaults||defaults;periods=o.periods||[];closingPeriod=o.closingPeriod||closingPeriod}}catch{}}
+
+const closingPeriodEnd=()=>{
+  if(!closingPeriod) return "";
+  const parts=closingPeriod.split("-");
+  if(parts.length<2) return "";
+  const y=Number(parts[0]),m=Number(parts[1]);
+  if(!y||!m) return "";
+  return toISO(new Date(y,m,0));
+};
 
 function renderProfile(){const name=profile.first&&profile.last?`${profile.first} ${profile.last}`:"Not set";setText("user-line",`${name} · ${profile.email||""}`);setText("user-badge",name?`${name}`:"Not signed in");el("login").style.display=(profile.email? "none":"flex")}
 function openProfile(){el("u-first").value=profile.first||"";el("u-last").value=profile.last||"";el("u-email").value=profile.email||"";el("login").style.display="flex"}
@@ -33,9 +43,11 @@ function setMode(m){
   el("amort-view").style.display=m==="amort"?"block":"none";
   el("activity-view").style.display=m==="activity"?"block":"none";
   el("settings-view").style.display=m==="settings"?"block":"none";
+  el("recon-view").style.display=m==="recon"?"block":"none";
   el("tab-amort").classList.toggle("active",m==="amort");
   el("tab-activity").classList.toggle("active",m==="activity");
   el("tab-settings").classList.toggle("active",m==="settings");
+  el("tab-recon").classList.toggle("active",m==="recon");
 }
 
 function renderMapUI(){
@@ -67,39 +79,40 @@ function renderItems(){
 
   items.forEach(it=>{
     const card=document.createElement("div");card.className="card";
+    const locked=Object.keys(it.reconciled||{}).some(p=>p<=closingPeriod);
     const h2=document.createElement("h2");h2.style.display="flex";h2.style.justifyContent="space-between";h2.style.alignItems="center";h2.innerHTML=`<span>${it.source.vendor} — ${it.source.invoiceNumber}</span>`;
-    const rm=document.createElement("button");rm.className="ghost";rm.textContent="Remove";rm.onclick=()=>{items=items.filter(x=>x.id!==it.id);save();renderItems()};h2.appendChild(rm);card.appendChild(h2);
+    const rm=document.createElement("button");rm.className="ghost";rm.textContent="Remove";rm.onclick=()=>{if(locked){alert("Transaction is reconciled and cannot be edited");return;}items=items.filter(x=>x.id!==it.id);save();renderItems();};h2.appendChild(rm);card.appendChild(h2);
 
     const c=document.createElement("div");c.className="content";
     const meta=document.createElement("div");meta.className="small";meta.style.marginBottom="8px";meta.textContent=`${toISO(it.source.invoiceDate)} · ${fmtUSD.format(it.source.amount)} · ${(it.source.seg2||"")}-${(it.source.seg3||"")}-${(it.source.seg4||"")}`;c.appendChild(meta);
     const grid=document.createElement("div");grid.className="grid3";
 
-    const months=document.createElement("div");months.innerHTML=`<label>Months</label>`;const monthsIn=document.createElement("input");monthsIn.type="number";monthsIn.min=1;monthsIn.value=it.amort.months;monthsIn.oninput=()=>{it.amort.months=Number(monthsIn.value||0);save()};months.appendChild(monthsIn);grid.appendChild(months);
-    const start=document.createElement("div");start.innerHTML=`<label>Start Date</label>`;const startIn=document.createElement("input");startIn.type="date";startIn.value=toISO(it.amort.startDate);startIn.oninput=()=>{it.amort.startDate=new Date(startIn.value);save()};start.appendChild(startIn);grid.appendChild(start);
-    const post=document.createElement("div");post.innerHTML=`<label>Post On</label>`;const postSel=document.createElement("select");postSel.innerHTML=`<option value="EOM">End of Month</option><option value="SameDay">Same Day</option>`;postSel.value=it.amort.postOn;postSel.onchange=()=>{it.amort.postOn=postSel.value;save()};post.appendChild(postSel);grid.appendChild(post);
-    const method=document.createElement("div");method.innerHTML=`<label>Method</label>`;const methodSel=document.createElement("select");methodSel.innerHTML=`<option value="straight">Straight-line</option><option value="prorata">Prorata</option>`;methodSel.value=it.amort.method;methodSel.onchange=()=>{it.amort.method=methodSel.value;save()};method.appendChild(methodSel);grid.appendChild(method);
+    const months=document.createElement("div");months.innerHTML=`<label>Months</label>`;const monthsIn=document.createElement("input");monthsIn.type="number";monthsIn.min=1;monthsIn.value=it.amort.months;monthsIn.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');monthsIn.value=it.amort.months;return;}it.amort.months=Number(monthsIn.value||0);save();};months.appendChild(monthsIn);grid.appendChild(months);
+    const start=document.createElement("div");start.innerHTML=`<label>Start Date</label>`;const startIn=document.createElement("input");startIn.type="date";startIn.value=toISO(it.amort.startDate);startIn.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');startIn.value=toISO(it.amort.startDate);return;}it.amort.startDate=new Date(startIn.value);save();};start.appendChild(startIn);grid.appendChild(start);
+    const post=document.createElement("div");post.innerHTML=`<label>Post On</label>`;const postSel=document.createElement("select");postSel.innerHTML=`<option value="EOM">End of Month</option><option value="SameDay">Same Day</option>`;postSel.value=it.amort.postOn;postSel.onchange=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');postSel.value=it.amort.postOn;return;}it.amort.postOn=postSel.value;save();};post.appendChild(postSel);grid.appendChild(post);
+    const method=document.createElement("div");method.innerHTML=`<label>Method</label>`;const methodSel=document.createElement("select");methodSel.innerHTML=`<option value="straight">Straight-line</option><option value="prorata">Prorata</option>`;methodSel.value=it.amort.method;methodSel.onchange=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');methodSel.value=it.amort.method;return;}it.amort.method=methodSel.value;save();};method.appendChild(methodSel);grid.appendChild(method);
 
-    const exp2=document.createElement("div");exp2.innerHTML=`<label>Expense Account</label>`;const exp2in=document.createElement("input");exp2in.type="text";exp2in.value=it.amort.expSeg2||"";exp2in.oninput=()=>{it.amort.expSeg2=exp2in.value;save();mark()};exp2.appendChild(exp2in);grid.appendChild(exp2);
-    const exp3=document.createElement("div");exp3.innerHTML=`<label>Department</label>`;const exp3in=document.createElement("input");exp3in.type="text";exp3in.value=it.amort.expSeg3||"";exp3in.oninput=()=>{it.amort.expSeg3=exp3in.value;save();mark()};exp3.appendChild(exp3in);grid.appendChild(exp3);
-    const exp4=document.createElement("div");exp4.innerHTML=`<label>Location</label>`;const exp4in=document.createElement("input");exp4in.type="text";exp4in.value=it.amort.expSeg4||"";exp4in.oninput=()=>{it.amort.expSeg4=exp4in.value;save();mark()};exp4.appendChild(exp4in);grid.appendChild(exp4);
+    const exp2=document.createElement("div");exp2.innerHTML=`<label>Expense Account</label>`;const exp2in=document.createElement("input");exp2in.type="text";exp2in.value=it.amort.expSeg2||"";exp2in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');exp2in.value=it.amort.expSeg2||'';return;}it.amort.expSeg2=exp2in.value;save();mark();};exp2.appendChild(exp2in);grid.appendChild(exp2);
+    const exp3=document.createElement("div");exp3.innerHTML=`<label>Department</label>`;const exp3in=document.createElement("input");exp3in.type="text";exp3in.value=it.amort.expSeg3||"";exp3in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');exp3in.value=it.amort.expSeg3||'';return;}it.amort.expSeg3=exp3in.value;save();mark();};exp3.appendChild(exp3in);grid.appendChild(exp3);
+    const exp4=document.createElement("div");exp4.innerHTML=`<label>Location</label>`;const exp4in=document.createElement("input");exp4in.type="text";exp4in.value=it.amort.expSeg4||"";exp4in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');exp4in.value=it.amort.expSeg4||'';return;}it.amort.expSeg4=exp4in.value;save();mark();};exp4.appendChild(exp4in);grid.appendChild(exp4);
 
     const expStatus=document.createElement("div");expStatus.className="status";expStatus.innerHTML=`<span id="expIcon">✖</span><input id="expName" type="text" readonly placeholder="Account name" />`;grid.appendChild(expStatus);
 
     const hr=document.createElement("div");hr.style.gridColumn="1/-1";hr.style.borderTop="1px solid #e5e7eb";hr.style.marginTop="8px";grid.appendChild(hr);
 
-    const as2=document.createElement("div");as2.innerHTML=`<label>Asset Account</label>`;const as2in=document.createElement("input");as2in.type="text";as2in.value=it.asset.seg2||"";as2in.oninput=()=>{it.asset.seg2=as2in.value;save();mark()};as2.appendChild(as2in);grid.appendChild(as2);
-    const as3=document.createElement("div");as3.innerHTML=`<label>Department</label>`;const as3in=document.createElement("input");as3in.type="text";as3in.value=it.asset.seg3||"";as3in.oninput=()=>{it.asset.seg3=as3in.value;save();mark()};as3.appendChild(as3in);grid.appendChild(as3);
-    const as4=document.createElement("div");as4.innerHTML=`<label>Location</label>`;const as4in=document.createElement("input");as4in.type="text";as4in.value=it.asset.seg4||"";as4in.oninput=()=>{it.asset.seg4=as4in.value;save();mark()};as4.appendChild(as4in);grid.appendChild(as4);
+    const as2=document.createElement("div");as2.innerHTML=`<label>Asset Account</label>`;const as2in=document.createElement("input");as2in.type="text";as2in.value=it.asset.seg2||"";as2in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');as2in.value=it.asset.seg2||'';return;}it.asset.seg2=as2in.value;save();mark();};as2.appendChild(as2in);grid.appendChild(as2);
+    const as3=document.createElement("div");as3.innerHTML=`<label>Department</label>`;const as3in=document.createElement("input");as3in.type="text";as3in.value=it.asset.seg3||"";as3in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');as3in.value=it.asset.seg3||'';return;}it.asset.seg3=as3in.value;save();mark();};as3.appendChild(as3in);grid.appendChild(as3);
+    const as4=document.createElement("div");as4.innerHTML=`<label>Location</label>`;const as4in=document.createElement("input");as4in.type="text";as4in.value=it.asset.seg4||"";as4in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');as4in.value=it.asset.seg4||'';return;}it.asset.seg4=as4in.value;save();mark();};as4.appendChild(as4in);grid.appendChild(as4);
 
     const astStatus=document.createElement("div");astStatus.className="status";astStatus.innerHTML=`<span id="astIcon">✖</span><input id="astName" type="text" readonly placeholder="Account name" />`;grid.appendChild(astStatus);
 
-    const memo=document.createElement("div");memo.style.gridColumn="1/-1";memo.innerHTML=`<label>Memo Template</label>`;const memoIn=document.createElement("input");memoIn.type="text";memoIn.value=it.amort.memoTemplate||defaults.amemo;memoIn.oninput=()=>{it.amort.memoTemplate=memoIn.value;save()};memo.appendChild(memoIn);grid.appendChild(memo);
+    const memo=document.createElement("div");memo.style.gridColumn="1/-1";memo.innerHTML=`<label>Memo Template</label>`;const memoIn=document.createElement("input");memoIn.type="text";memoIn.value=it.amort.memoTemplate||defaults.amemo;memoIn.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');memoIn.value=it.amort.memoTemplate||defaults.amemo;return;}it.amort.memoTemplate=memoIn.value;save();};memo.appendChild(memoIn);grid.appendChild(memo);
 
     const btns=document.createElement("div");btns.style.gridColumn="1/-1";
     const build=document.createElement("button");build.className="secondary";build.textContent="Build Schedule";
-    build.onclick=()=>{it.schedule=buildSchedule(it);save();renderItems()};
+    build.onclick=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');return;}it.schedule=buildSchedule(it);save();renderItems();};
     const val=document.createElement("button");val.className="secondary";val.style.marginLeft="8px";val.textContent="Validate";
-    val.onclick=()=>mark(true);
+    val.onclick=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');return;}mark(true);};
     btns.appendChild(build);btns.appendChild(val);grid.appendChild(btns);
 
     const scNote=document.createElement("div");scNote.style.gridColumn="1/-1";c.appendChild(grid);
@@ -128,11 +141,26 @@ function renderItems(){
       tbl.appendChild(tb);sc.appendChild(tbl);c.appendChild(sc);
     }
 
-    card.appendChild(c);host.appendChild(card);
+    card.appendChild(c);
+    if(locked){
+      const ov=document.createElement('div');
+      ov.style.position='absolute';ov.style.inset='0';
+      ov.style.background='rgba(255,255,255,0.6)';
+      ov.style.display='flex';ov.style.alignItems='center';ov.style.justifyContent='center';
+      ov.style.fontWeight='700';ov.textContent='Reconciled';
+      ov.onclick=()=>alert('Transaction is reconciled and cannot be edited');
+      card.style.position='relative';card.appendChild(ov);
+    }
+    host.appendChild(card);
   });
+  if(mode==='recon') renderReconciliation();
 }
 
-function renderReclass(){const host=el("reclass-items");host.innerHTML="";el("reclass-empty").style.display=reclassItems.length?"none":"block";reclassItems.forEach(it=>{const card=document.createElement("div");card.className="card";const h2=document.createElement("h2");h2.style.display="flex";h2.style.justifyContent="space-between";h2.style.alignItems="center";h2.innerHTML=`<span>${it.vendor} — ${it.invoiceNumber}</span>`;const rm=document.createElement("button");rm.className="ghost";rm.textContent="Remove";rm.onclick=()=>{reclassItems=reclassItems.filter(x=>x.id!==it.id);save();renderReclass()};h2.appendChild(rm);card.appendChild(h2);const c=document.createElement("div");c.className="content";const meta=document.createElement("div");meta.className="small";meta.style.marginBottom="8px";meta.textContent=`From ${(it.fromSeg2||"")}-${(it.fromSeg3||"")}-${(it.fromSeg4||"")} · Amount ${fmtUSD.format(it.amount)}`;c.appendChild(meta);const grid=document.createElement("div");grid.className="grid3";const t2=document.createElement("div");t2.innerHTML=`<label>To Account</label>`;const t2in=document.createElement("input");t2in.type="text";t2in.value=it.toSeg2||"";t2in.oninput=()=>{it.toSeg2=t2in.value;save();mark()};t2.appendChild(t2in);grid.appendChild(t2);const t3=document.createElement("div");t3.innerHTML=`<label>Department</label>`;const t3in=document.createElement("input");t3in.type="text";t3in.value=it.toSeg3||"";t3in.oninput=()=>{it.toSeg3=t3in.value;save();mark()};t3.appendChild(t3in);grid.appendChild(t3);const t4=document.createElement("div");t4.innerHTML=`<label>Location</label>`;const t4in=document.createElement("input");t4in.type="text";t4in.value=it.toSeg4||"";t4in.oninput=()=>{it.toSeg4=t4in.value;save();mark()};t4.appendChild(t4in);grid.appendChild(t4);const memo=document.createElement("div");memo.style.gridColumn="1/-1";memo.innerHTML=`<label>Memo</label>`;const memoIn=document.createElement("input");memoIn.type="text";memoIn.value=it.memo||"";memoIn.oninput=()=>{it.memo=memoIn.value;save()};memo.appendChild(memoIn);grid.appendChild(memo);const note=document.createElement("div");note.style.gridColumn="1/-1";c.appendChild(grid);c.appendChild(note);function mark(){[t2in,t3in,t4in].forEach(x=>x.classList.remove("invalid"));const desc=acctLookup(it.toSeg2,it.toSeg3,it.toSeg4);note.innerHTML=desc?`<div class="valid-note">Target: ${desc}</div>`:(it.toSeg2||it.toSeg3||it.toSeg4)?`<div class="invalid-note">Target combo not found</div>`:""}mark();card.appendChild(c);host.appendChild(card)})}
+function renderReclass(){const host=el("reclass-items");host.innerHTML="";el("reclass-empty").style.display=reclassItems.length?"none":"block";reclassItems.forEach(it=>{const card=document.createElement("div");card.className="card";const locked=Object.keys(it.reconciled||{}).some(p=>p<=closingPeriod);const h2=document.createElement("h2");h2.style.display="flex";h2.style.justifyContent="space-between";h2.style.alignItems="center";h2.innerHTML=`<span>${it.vendor} — ${it.invoiceNumber}</span>`;const rm=document.createElement("button");rm.className="ghost";rm.textContent="Remove";rm.onclick=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');return;}reclassItems=reclassItems.filter(x=>x.id!==it.id);save();renderReclass()};h2.appendChild(rm);card.appendChild(h2);const c=document.createElement("div");c.className="content";const meta=document.createElement("div");meta.className="small";meta.style.marginBottom="8px";meta.textContent=`From ${(it.fromSeg2||"")}-${(it.fromSeg3||"")}-${(it.fromSeg4||"")} · Amount ${fmtUSD.format(it.amount)}`;c.appendChild(meta);const grid=document.createElement("div");grid.className="grid3";const t2=document.createElement("div");t2.innerHTML=`<label>To Account</label>`;const t2in=document.createElement("input");t2in.type="text";t2in.value=it.toSeg2||"";t2in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');t2in.value=it.toSeg2||'';return;}it.toSeg2=t2in.value;save();mark()};t2.appendChild(t2in);grid.appendChild(t2);const t3=document.createElement("div");t3.innerHTML=`<label>Department</label>`;const t3in=document.createElement("input");t3in.type="text";t3in.value=it.toSeg3||"";t3in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');t3in.value=it.toSeg3||'';return;}it.toSeg3=t3in.value;save();mark()};t3.appendChild(t3in);grid.appendChild(t3);const t4=document.createElement("div");t4.innerHTML=`<label>Location</label>`;const t4in=document.createElement("input");t4in.type="text";t4in.value=it.toSeg4||"";t4in.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');t4in.value=it.toSeg4||'';return;}it.toSeg4=t4in.value;save();mark()};t4.appendChild(t4in);grid.appendChild(t4);const memo=document.createElement("div");memo.style.gridColumn="1/-1";memo.innerHTML=`<label>Memo</label>`;const memoIn=document.createElement("input");memoIn.type="text";memoIn.value=it.memo||"";memoIn.oninput=()=>{if(locked){alert('Transaction is reconciled and cannot be edited');memoIn.value=it.memo||'';return;}it.memo=memoIn.value;save()};memo.appendChild(memoIn);grid.appendChild(memo);const note=document.createElement("div");note.style.gridColumn="1/-1";c.appendChild(grid);c.appendChild(note);function mark(){[t2in,t3in,t4in].forEach(x=>x.classList.remove("invalid"));const desc=acctLookup(it.toSeg2,it.toSeg3,it.toSeg4);note.innerHTML=desc?`<div class="valid-note">Target: ${desc}</div>`:(it.toSeg2||it.toSeg3||it.toSeg4)?`<div class="invalid-note">Target combo not found</div>`:""}mark();card.appendChild(c);if(locked){const ov=document.createElement('div');ov.style.position='absolute';ov.style.inset='0';ov.style.background='rgba(255,255,255,0.6)';ov.style.display='flex';ov.style.alignItems='center';ov.style.justifyContent='center';ov.style.fontWeight='700';ov.textContent='Reconciled';ov.onclick=()=>alert('Transaction is reconciled and cannot be edited');card.style.position='relative';card.appendChild(ov);}host.appendChild(card)})}
+
+function renderReconciliation(){const host=el('recon-table');if(!host)return;const period=el('recon-period').value||closingPeriod||"";const t=document.createElement('table');t.innerHTML='<thead><tr><th>Type</th><th>Info</th><th>Account</th><th>Reconciled</th></tr></thead>';const tb=document.createElement('tbody');items.forEach(it=>{const combo=`${it.asset.seg2||it.source.seg2||""}-${it.asset.seg3||it.source.seg3||""}-${it.asset.seg4||it.source.seg4||""}`;const tr=document.createElement('tr');tr.innerHTML=`<td>Amort</td><td>${it.source.vendor} ${it.source.invoiceNumber}</td><td>${combo}</td>`;const td=document.createElement('td');const chk=document.createElement('input');chk.type='checkbox';chk.checked=!!(it.reconciled&&it.reconciled[period]);chk.onchange=()=>{it.reconciled=it.reconciled||{};if(chk.checked)it.reconciled[period]=true;else delete it.reconciled[period];save();renderItems();renderReclass();};td.appendChild(chk);tr.appendChild(td);tb.appendChild(tr)});reclassItems.forEach(it=>{const combo=`${it.fromSeg2||""}-${it.fromSeg3||""}-${it.fromSeg4||""}`;const tr=document.createElement('tr');tr.innerHTML=`<td>Reclass</td><td>${it.vendor} ${it.invoiceNumber}</td><td>${combo}</td>`;const td=document.createElement('td');const chk=document.createElement('input');chk.type='checkbox';chk.checked=!!(it.reconciled&&it.reconciled[period]);chk.onchange=()=>{it.reconciled=it.reconciled||{};if(chk.checked)it.reconciled[period]=true;else delete it.reconciled[period];save();renderItems();renderReclass();};td.appendChild(chk);tr.appendChild(td);tb.appendChild(tr)});t.appendChild(tb);host.innerHTML='';host.appendChild(t)}
+
+function renderPeriods(){const tb=el('period-table')?.querySelector('tbody');if(!tb)return;tb.innerHTML='';periods.forEach((p,i)=>{const tr=document.createElement('tr');const td0=document.createElement('td');const in0=document.createElement('input');in0.type='month';in0.value=p.period||'';in0.oninput=()=>{p.period=in0.value;save();};td0.appendChild(in0);tr.appendChild(td0);const td1=document.createElement('td');const in1=document.createElement('input');in1.type='date';in1.value=p.begin||'';in1.oninput=()=>{p.begin=in1.value;save();};td1.appendChild(in1);tr.appendChild(td1);const td2=document.createElement('td');const in2=document.createElement('input');in2.type='date';in2.value=p.end||'';in2.oninput=()=>{p.end=in2.value;save();};td2.appendChild(in2);tr.appendChild(td2);const td3=document.createElement('td');const btn=document.createElement('button');btn.className='ghost';btn.textContent='✖';btn.onclick=()=>{periods.splice(i,1);save();renderPeriods();};td3.appendChild(btn);tr.appendChild(td3);tb.appendChild(tr);})}
 
 function apModuleTotal(){return groups.reduce((a,g)=>a+(g.amount||0),0)}
 function apNetTB(){if(!summaryTB.length)return 0;const rows=summaryTB.filter(r=>{const mod=(r["modsrc"]??r["Modsrc"]??r["MODSRC"]??"").toString().toUpperCase();const j=(r["jnlsrc"]??r["Jnlsrc"]??r["JNLSRC"]??"").toString().toUpperCase();return mod.includes("AP")&&j.includes("BCHCLS")});const dKey=Object.keys(summaryTB[0]||{}).find(k=>k.toLowerCase().includes("debit"));const cKey=Object.keys(summaryTB[0]||{}).find(k=>k.toLowerCase().includes("credit"));return round2(rows.reduce((a,r)=>a+(Number(dKey?r[dKey]:0)||0)-(Number(cKey?r[cKey]:0)||0),0))}
@@ -254,7 +282,7 @@ function monthKey(d){return d.getFullYear()+"-"+String(d.getMonth()+1).padStart(
 function actCalcForCombo(combo,refDate){const months=actMonths(refDate);const map=Object.fromEntries(months.map(m=>[monthKey(m),{dr:0,cr:0}]));items.forEach(it=>{(it.schedule||[]).forEach(r=>{const d=new Date(r.date);const k=monthKey(new Date(d.getFullYear(),d.getMonth(),1));if(!map[k])return;if(r.debitCombo===combo) map[k].dr+=Number(r.amount)||0;if(r.creditCombo===combo) map[k].cr+=Number(r.amount)||0})});reclassItems.forEach(j=>{const k=monthKey(new Date(refDate||new Date()));if(j.toSeg2+"-"+j.toSeg3+"-"+j.toSeg4===combo) map[k].dr+=Number(j.amount)||0;if(j.fromSeg2+"-"+j.fromSeg3+"-"+j.fromSeg4===combo) map[k].cr+=Number(j.amount)||0});return {months,map}}
 function actTBForCombo(combo,refDate){if(!detailTB.length)return null;const seg2k=Object.keys(detailTB[0]).find(k=>k.toLowerCase().includes("seg2")||k.toLowerCase().includes("segnumtwo"));const seg3k=Object.keys(detailTB[0]).find(k=>k.toLowerCase().includes("seg3")||k.toLowerCase().includes("segnumthr"));const seg4k=Object.keys(detailTB[0]).find(k=>k.toLowerCase().includes("seg4")||k.toLowerCase().includes("segnumfou"));const datek=Object.keys(detailTB[0]).find(k=>/date|trndat|trandat|posting/i.test(k));const debitk=Object.keys(detailTB[0]).find(k=>/debit|debitamt|debamt/i.test(k));const creditk=Object.keys(detailTB[0]).find(k=>/credit|crdamt|cramt/i.test(k));if(!seg2k||!seg3k||!seg4k||!datek||!(debitk||creditk))return null;const months=actMonths(refDate);const map=Object.fromEntries(months.map(m=>[monthKey(m),{dr:0,cr:0}]));detailTB.forEach(r=>{const k=[r[seg2k],r[seg3k],r[seg4k]].map(x=>String(x||"")).join("-");if(k!==combo)return;const d=parseDate(r[datek]);if(!d)return;const mk=monthKey(new Date(d.getFullYear(),d.getMonth(),1));if(!map[mk])return;const dr=Number((debitk&&r[debitk])||0)||0;const cr=Number((creditk&&r[creditk])||0)||0;map[mk].dr+=dr;map[mk].cr+=cr});return {months,map}}
 
-function buildActivityDefaults(){el("act-period").value=periodEnd||toISO(new Date());buildActivitySelect();renderActivity()}
+function buildActivityDefaults(){el("act-period").value=periodEnd||closingPeriodEnd()||toISO(new Date());buildActivitySelect();renderActivity()}
 
 function handleImportSchedule(f){const r=new FileReader();r.onload=e=>{const rows=String(e.target.result).split(/\r?\n/).map(l=>l.split(/,|\t/));const hdr=rows.shift().map(x=>x.trim().toLowerCase());const idx=(n)=>hdr.indexOf(n);rows.forEach(c=>{if(!c.length)return;const o={date:c[idx("date")],amount:Number(c[idx("amount")]||0),debitCombo:`${c[idx("debitseg2")]||""}-${c[idx("debitseg3")]||""}-${c[idx("debitseg4")]||""}`,creditCombo:`${c[idx("creditseg2")]||""}-${c[idx("creditseg3")]||""}-${c[idx("creditseg4")]||""}`,memo:c[idx("memo")]||""};items.push({id:uid(),source:{type:"Import",vendor:"Imported",invoiceNumber:"",amount:o.amount,invoiceDate:parseDate(o.date)||new Date(),description:o.memo,seg2:o.creditCombo.split("-")[0],seg3:o.creditCombo.split("-")[1],seg4:o.creditCombo.split("-")[2],lines:[]},amort:{enabled:false,method:"straight",months:1,startDate:parseDate(o.date)||new Date(),postOn:"EOM",expSeg2:o.debitCombo.split("-")[0],expSeg3:o.debitCombo.split("-")[1],expSeg4:o.debitCombo.split("-")[2],memoTemplate:o.memo},asset:{seg2:o.creditCombo.split("-")[0],seg3:o.creditCombo.split("-")[1],seg4:o.creditCombo.split("-")[2]},schedule:[{date:parseDate(o.date)||new Date(),amount:o.amount,debitCombo:o.debitCombo,creditCombo:o.creditCombo,memo:o.memo}]})});save();renderItems();renderActivity()};r.readAsText(f)}
 function handleImportJE(f){const r=new FileReader();r.onload=e=>{const rows=String(e.target.result).split(/\r?\n/).map(l=>l.split(/\t|,/));const hdr=rows.shift().map(x=>x.trim().toLowerCase());const g=(n)=>hdr.indexOf(n);rows.forEach(c=>{if(c.length<13)return;const deb=Number(c[g("debamt")]||0)||0;const crd=Number(c[g("crdamt")]||0)||0;const s2=c[g("segnumt")]||c[g("segnumt")];const s3=c[g("segnumt")]||c[g("segnumt")];const s4=c[g("segnumf")]||c[g("segnumf")];const memo=c[g("lngdsc")]||"";if(deb>0){reclassItems.push({id:uid(),vendor:"Imported JE",invoiceNumber:"",amount:deb,fromSeg2:"",fromSeg3:"",fromSeg4:"",toSeg2:s2,toSeg3:s3,toSeg4:s4,memo})}if(crd>0){reclassItems.push({id:uid(),vendor:"Imported JE",invoiceNumber:"",amount:crd,fromSeg2:s2,fromSeg3:s3,fromSeg4:s4,toSeg2:"",toSeg3:"",toSeg4:"",memo})}});save();renderReclass();renderActivity()};r.readAsText(f)}
@@ -276,11 +304,16 @@ el("acct-build").addEventListener("click",()=>{buildAcctIndex();save()});
 
 el("tab-amort").onclick=()=>setMode("amort");
 el("tab-activity").onclick=()=>{setMode("activity");buildActivityDefaults()};
+el("tab-recon").onclick=()=>{setMode("recon");el("recon-period").value=closingPeriod||"";renderReconciliation()};
 el("tab-settings").onclick=()=>{setMode("settings");renderSettings()};
 el("act-refresh").onclick=renderActivity;
 el("act-select").addEventListener("change",()=>{el("act-search").value=el("act-select").value;renderActivity()});
 el("act-search").addEventListener("input",renderActivity);
 el("act-period").addEventListener("input",renderActivity);
+
+el("recon-period").addEventListener("input",renderReconciliation);
+el("set-closing").addEventListener("input",e=>{closingPeriod=e.target.value;periodEnd=closingPeriodEnd();if(periodEnd){el("periodEnd").value=periodEnd;el("act-period").value=periodEnd;}el("recon-period").value=closingPeriod;save();});
+el("add-period").onclick=()=>{periods.push({period:"",begin:"",end:""});renderPeriods();save()};
 
 el("imp-sched").addEventListener("change",e=>{const f=e.target.files?.[0];if(f)handleImportSchedule(f)});
 el("imp-je").addEventListener("change",e=>{const f=e.target.files?.[0];if(f)handleImportJE(f)});
@@ -304,6 +337,8 @@ function renderSettings(){
   el("set-amm").value=defaults.amm||actualMM||"";
   el("set-amemo").value=defaults.amemo||"";
   el("set-jnltitle").value=defaults.jnltitle||journalTitle||"";
+  el("set-closing").value=closingPeriod||"";
+  renderPeriods();
 }
 el("set-save").onclick=()=>{
   defaults.fyy=el("set-fyy").value.replace(/[^0-9]/g,"").slice(-2);
@@ -321,5 +356,7 @@ load();renderProfile();setMode("amort");
 if(defaults.fyy&&!fiscalYY)fiscalYY=defaults.fyy;
 if(defaults.amm&&!actualMM)actualMM=defaults.amm;
 if(defaults.jnltitle&&!journalTitle)journalTitle=defaults.jnltitle;
+if(!periodEnd&&closingPeriod)periodEnd=closingPeriodEnd();
+el("recon-period").value=closingPeriod||"";
 if(periodEnd)el("periodEnd").value=periodEnd;if(fiscalYY)el("fiscalYY").value=fiscalYY;if(actualMM)el("actualMM").value=actualMM;if(seqStart)el("seqStart").value=seqStart;if(journalTitle)el("jnlTitle").value=journalTitle;
 renderItems();renderReclass();

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
       <div class="tabs">
         <button id="tab-amort" class="active">Amortization Builder</button>
         <button id="tab-activity">Account Activity & Schedules</button>
+        <button id="tab-recon">Reconciliation</button>
         <button id="tab-settings">Settings</button>
       </div>
       <div class="row">
@@ -221,6 +222,16 @@
       </div>
     </div>
 
+    <div id="recon-view" style="display:none">
+      <div class="card">
+        <h2>Reconciliation</h2>
+        <div class="content">
+          <div class="row"><div><label>Period</label><input id="recon-period" type="month"/></div></div>
+          <div id="recon-table" class="scroll" style="margin-top:8px"></div>
+        </div>
+      </div>
+    </div>
+
     <div id="settings-view" style="display:none">
       <div class="card">
         <h2>Settings</h2>
@@ -232,6 +243,21 @@
           <div class="row" style="grid-column:1/-1;margin-top:6px">
             <button id="set-save">Save</button>
             <span class="small">These defaults prefill Export and new amortizations.</span>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Fiscal Periods</h2>
+        <div class="content">
+          <div class="row" style="align-items:center;gap:12px">
+            <div><label>Current Closing Period</label><input id="set-closing" type="month"/></div>
+            <button id="add-period" class="secondary">Add Period</button>
+          </div>
+          <div class="scroll" style="margin-top:8px">
+            <table id="period-table" style="width:100%">
+              <thead><tr><th>Period</th><th>Begin</th><th>End</th><th></th></tr></thead>
+              <tbody></tbody>
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add Reconciliation tab to mark transactions as reconciled by period and block edits on reconciled items
- Introduce fiscal period table and closing period setting to prefill period selectors across the app

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_b_689dd799e7a4832cb013250e6b02b5c6