### PR TITLE
Allow multiple account combos in activity view

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,8 +192,8 @@
         <h2>Activity Browser & Amortization Schedule</h2>
         <div class="content">
           <div class="grid3">
-            <div><label>Account Combo</label><input id="act-search" type="text" placeholder="11415-000-02"/></div>
-            <div><label>Select From GL Accounts</label><select id="act-select"></select></div>
+            <div><label>Account Combo</label><input id="act-search" type="text" placeholder="11415-000-02,11415-000-03"/></div>
+            <div><label>Select From GL Accounts</label><select id="act-select" multiple></select></div>
             <div><label>Reference Period End</label><input id="act-period" type="date"/></div>
           </div>
           <div class="row" style="margin-top:8px"><button id="act-refresh">Refresh</button></div>


### PR DESCRIPTION
## Summary
- allow selecting multiple GL account combos and aggregate their activity totals
- sync comma-separated account combo input with new multi-select control

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689dd7984574832cb50611771096805d