### PR TITLE
feat: allow configurable master schedule path

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,7 @@
           <div><label>Default Actual Month (MM)</label><input id="set-amm" type="text" maxlength="2"/></div>
           <div style="grid-column:1/-1"><label>Default Amort Memo Template</label><input id="set-amemo" type="text" placeholder="{{vendor}} {{invnum}} amortization ({{start}}–{{end}})"/></div>
           <div style="grid-column:1/-1"><label>Default Journal Title</label><input id="set-jnltitle" type="text" placeholder="Standard Amortization Entry"/></div>
+          <div style="grid-column:1/-1"><label>Master Schedule File</label><input id="set-masterfile" type="text"/></div>
           <div style="grid-column:1/-1;margin-top:12px">
             <label>Account Groups</label>
             <table id="grp-table">


### PR DESCRIPTION
## Summary
- allow overriding master schedule path via localStorage and settings UI
- check for existing master file before loading; only save when user actions require

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689df24a5f94832c8e47ce91fb279cf4