### PR TITLE
Initialize master workbook with header row

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,12 @@ async function loadMasterFile(){
         masterWB=XLSX.read(data,{type:"array"});
       }
     }
-  }catch{}
+  }catch{
+    masterWB=XLSX.utils.book_new();
+    const ws=XLSX.utils.aoa_to_sheet([["type","period","trndat","date","je","amount","debit","credit","memo","user","timestamp","vendor","invoiceNumber"]]);
+    XLSX.utils.book_append_sheet(masterWB,ws,MASTER_SHEET);
+    saveMasterFile();
+  }
   computeLatestClosedPeriod();
 }
 function saveMasterFile(){if(masterWB) XLSX.writeFile(masterWB,masterFilePath);}


### PR DESCRIPTION
## Summary
- Initialize master workbook with a header row when loading fails
- Persist the new workbook so generated files include column descriptions

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689df41fc470832c842d5ed0b39a540b