### PR TITLE
Add home view and mode switching

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ let actionsByKey={},items=[],reclassItems=[];
 let periodEnd="",fiscalYY="",actualMM="",seqStart="01",journalTitle="Standard Amortization Entry";
 
   let defaults={fyy:"",amm:"",amemo:"{{vendor}} {{invnum}} amortization ({{start}}–{{end}})",jnltitle:"Standard Amortization Entry"};
-  let mode="amort";
+  let mode="home";
   let activitySection="schedule";
 
 
@@ -101,10 +101,16 @@ function applyProfile(){profile.first=el("u-first").value.trim();profile.last=el
 
 function setMode(m){
   mode=m;
+  el("home-view").style.display=m==="home"?"block":"none";
+  el("app-bar").style.display=m==="home"?"none":"flex";
+  el("home-btn").style.display=m==="home"?"none":"inline-block";
+  el("login-card").style.display=m==="home"?"none":"block";
   el("amort-view").style.display=m==="amort"?"block":"none";
   el("activity-view").style.display=m==="activity"?"block":"none";
   el("settings-view").style.display=m==="settings"?"block":"none";
   el("recon-view").style.display=m==="recon"?"block":"none";
+  el("intangible-view").style.display=m==="intangible"?"block":"none";
+  el("accrual-view").style.display=m==="accrual"?"block":"none";
   el("tab-amort").classList.toggle("active",m==="amort");
   el("tab-activity").classList.toggle("active",m==="activity");
   el("tab-settings").classList.toggle("active",m==="settings");
@@ -426,6 +432,11 @@ el("tab-amort").onclick=()=>setMode("amort");
 el("tab-activity").onclick=()=>{setMode("activity");buildActivityDefaults()};
 el("tab-settings").onclick=()=>{setMode("settings");renderSettings()};
 
+el("btn-prepaid").onclick=()=>setMode("amort");
+el("btn-intangible").onclick=()=>setMode("intangible");
+el("btn-accruals").onclick=()=>setMode("accrual");
+el("home-btn").onclick=()=>setMode("home");
+
   el("act-refresh").onclick=renderActivity;
   el("act-select").addEventListener("change",()=>{el("act-search").value=el("act-select").value;renderActivity()});
   el("act-search").addEventListener("input",renderActivity);
@@ -501,7 +512,7 @@ el("grp-add").onclick=()=>{defaults.groups.push({group:"",seg2:"",seg3:"",seg4:"
 
 el("edit-user").onclick=openProfile;el("force-login").onclick=openProfile;el("u-save").onclick=()=>{applyProfile();el("login").style.display="none"};
 
-load();renderProfile();setMode("amort");
+load();renderProfile();setMode("home");
 loadMasterFile();
 if(defaults.fyy&&!fiscalYY)fiscalYY=defaults.fyy;
 if(defaults.amm&&!actualMM)actualMM=defaults.amm;

--- a/index.html
+++ b/index.html
@@ -56,8 +56,19 @@
 </head>
 <body>
   <div class="container">
-    <div class="bar">
-      <div style="font-weight:700">Sun Orchard Balance Sheet Reconciler</div>
+    <div id="home-view">
+      <h1>Sun Orchard Balance Reconciliation Tool</h1>
+      <div class="row">
+        <button id="btn-prepaid">Prepaid</button>
+        <button id="btn-intangible">Intangible</button>
+        <button id="btn-accruals">Accruals</button>
+      </div>
+    </div>
+    <div id="app-bar" class="bar">
+      <div class="row">
+        <button id="home-btn" class="secondary" style="display:none">Home</button>
+        <div style="font-weight:700">Sun Orchard Balance Sheet Reconciler</div>
+      </div>
       <div class="tabs">
         <button id="tab-amort" class="active">Amortization Builder</button>
         <button id="tab-activity">Account Activity & Schedules</button>
@@ -70,7 +81,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div id="login-card" class="card">
       <h2>0) Login</h2>
       <div class="content">
         <div class="row">
@@ -271,9 +282,15 @@
         </div>
       </div>
     </div>
+    <div id="intangible-view" style="display:none">
+      <h2>Intangible Reconciliation</h2>
+      <p>Coming soon</p>
+    </div>
+    <div id="accrual-view" style="display:none">
+      <h2>Accrual Reconciliation</h2>
+      <p>Coming soon</p>
+    </div>
   </div>
-
-
 
   <div id="dlg" class="dialog-backdrop">
     <div class="dialog">


### PR DESCRIPTION
## Summary
- Add home view with buttons for Prepaid, Intangible, and Accrual modules
- Include Home button in app bar and toggle sections based on mode
- Provide placeholder Intangible and Accrual views

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_689dfa7d276c832c9f1c5a879e071e50