### PR TITLE
Ensure users land on home view after login

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,7 +97,14 @@ function load(){try{const s=localStorage.getItem(STORAGE);if(s){const o=JSON.par
 
 function renderProfile(){const name=profile.first&&profile.last?`${profile.first} ${profile.last}`:"Not set";setText("user-line",`${name} · ${profile.email||""}`);setText("user-badge",name?`${name}`:"Not signed in");el("login").style.display=(profile.email? "none":"flex")}
 function openProfile(){el("u-first").value=profile.first||"";el("u-last").value=profile.last||"";el("u-email").value=profile.email||"";el("login").style.display="flex"}
-function applyProfile(){profile.first=el("u-first").value.trim();profile.last=el("u-last").value.trim();profile.email=el("u-email").value.trim();save();renderProfile()}
+function applyProfile(){
+  profile.first = el("u-first").value.trim();
+  profile.last = el("u-last").value.trim();
+  profile.email = el("u-email").value.trim();
+  save();
+  renderProfile();
+  setMode("home");
+}
 
 function setMode(m){
   mode = m;
@@ -111,6 +118,9 @@ function setMode(m){
     el("app-bar").style.display = "none";
     el("home-btn").style.display = "none";
     el("login-card").style.display = "none";
+    ["amort", "activity", "settings", "recon"].forEach(t => {
+      el(`tab-${t}`).classList.remove("active");
+    });
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -64,13 +64,13 @@
         <button id="btn-accruals">Accruals</button>
       </div>
     </div>
-    <div id="app-bar" class="bar">
+    <div id="app-bar" class="bar" style="display:none">
       <div class="row">
         <button id="home-btn" class="secondary" style="display:none">Home</button>
         <div style="font-weight:700">Sun Orchard Balance Sheet Reconciler</div>
       </div>
       <div class="tabs">
-        <button id="tab-amort" class="active">Amortization Builder</button>
+        <button id="tab-amort">Amortization Builder</button>
         <button id="tab-activity">Account Activity & Schedules</button>
         <button id="tab-recon">Reconciliation</button>
         <button id="tab-settings">Settings</button>
@@ -81,7 +81,7 @@
       </div>
     </div>
 
-    <div id="login-card" class="card">
+    <div id="login-card" class="card" style="display:none">
       <h2>0) Login</h2>
       <div class="content">
         <div class="row">
@@ -91,7 +91,7 @@
       </div>
     </div>
 
-    <div id="amort-view">
+    <div id="amort-view" style="display:none">
       <div class="card">
         <h2>1) Upload Workbook</h2>
         <div class="content">


### PR DESCRIPTION
## Summary
- Return to the Home view after saving a user profile
- Clear tab active state and hide app bar/login/amortization views when Home mode is selected
- Remove default active Amortization tab and hide non-home views on initial load

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_689e068e2634832cbbdfaa10e215b282